### PR TITLE
Ensure worker threads run as daemons

### DIFF
--- a/main.py
+++ b/main.py
@@ -358,7 +358,7 @@ class VideoDownloader(ctk.CTk):
                 messagebox.showerror("错误", error_msg)
                 self.status_label.configure(text="获取格式失败")
 
-        Thread(target=fetch).start()
+        Thread(target=fetch, daemon=True).start()
 
     def start_download(self):
         def download():
@@ -414,7 +414,7 @@ class VideoDownloader(ctk.CTk):
                 messagebox.showerror("错误", error_msg)
                 self.status_label.configure(text="下载失败")
 
-        Thread(target=download).start()
+        Thread(target=download, daemon=True).start()
 
     def progress_hook(self, d):
         if d['status'] == 'downloading':

--- a/podcast_downloader.py
+++ b/podcast_downloader.py
@@ -291,7 +291,7 @@ class PodcastDownloader(ctk.CTkFrame):
             finally:
                 self.fetch_button.configure(state="normal")
                 
-        Thread(target=fetch).start()
+        Thread(target=fetch, daemon=True).start()
         
     def download_selected(self):
         def download():
@@ -384,7 +384,7 @@ class PodcastDownloader(ctk.CTkFrame):
             finally:
                 self.download_button.configure(state="normal")
                 
-        Thread(target=download).start()
+        Thread(target=download, daemon=True).start()
         
     def select_all(self):
         for item in self.tree.get_children():


### PR DESCRIPTION
## Summary
- allow thread workers to run as daemons so they don't block exit

## Testing
- `python -m py_compile main.py podcast_downloader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842c7a80a888327a5c5706a3ea376d5